### PR TITLE
Astro deploy and image build hardening

### DIFF
--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -9,3 +9,21 @@ jobs:
         with:
           fetch-depth: 0
       - run: npm ci && npm run test:astro
+
+  image-build:
+    if: '${{ github.event.pull_request.head.repo.full_name == github.repository }}'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: false
+          build-args: |
+            PUBLIC_GOOGLE_ANALYTICS_ID=${{ secrets.NEXT_PUBLIC_GOOGLE_ANALYTICS_ID }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN npm ci
 COPY . .
 RUN npm run build:post-history && npm run build:astro
 
-FROM nginx:1.31.0-alpine3.23 AS runtime
+FROM mirror.gcr.io/library/nginx:1.31.0-alpine3.23 AS runtime
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=build /app/dist /usr/share/nginx/html
 EXPOSE 80

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN npm ci
 COPY . .
 RUN npm run build:post-history && npm run build:astro
 
-FROM nginx:1.27-alpine AS runtime
+FROM nginx:1.29.8-alpine AS runtime
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=build /app/dist /usr/share/nginx/html
 EXPOSE 80

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN npm ci
 COPY . .
 RUN npm run build:post-history && npm run build:astro
 
-FROM nginx:1.29.8-alpine AS runtime
+FROM nginx:1.31.0-alpine3.23 AS runtime
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=build /app/dist /usr/share/nginx/html
 EXPOSE 80


### PR DESCRIPTION
- Move runtime base image to mirror.gcr.io\n- Keep publish on master only\n- Validate container image builds on pull requests without pushing\n