### PR TITLE
Restore RSS feed at /posts/index.xml

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,8 @@
         "retext-stringify": "^4.0.0",
         "strip-markdown": "^6.0.0",
         "unified": "^11.0.5",
-        "unist-util-visit": "^5.0.0"
+        "unist-util-visit": "^5.0.0",
+        "xml-escape": "^1.1.0"
       },
       "devDependencies": {
         "@astrojs/react": "^5.0.6",
@@ -32,6 +33,7 @@
         "@types/node": "^25.9.1",
         "@types/react": "^19.2.15",
         "@types/react-dom": "^19.2.3",
+        "@types/xml-escape": "^1.1.3",
         "@vitejs/plugin-react": "^5.2.0",
         "@vitest/ui": "^4.1.7",
         "astro": "^6.4.2",
@@ -2463,6 +2465,13 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/xml-escape": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@types/xml-escape/-/xml-escape-1.1.3.tgz",
+      "integrity": "sha512-xyp280LPQAj/IFwv4cdNgToDMtpGMADWr5uDbi1der5zqldBnk6VVLF/8N016SjgFDKi9UA4YW6Q072vhDaegA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@ungap/structured-clone": {
@@ -8099,6 +8108,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xml-escape": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/xml-escape/-/xml-escape-1.1.0.tgz",
+      "integrity": "sha512-B/T4sDK8Z6aUh/qNr7mjKAwwncIljFuUP+DO/D5hloYFj+90O88z8Wf7oSucZTHxBAsC1/CTP4rtx/x1Uf72Mg==",
+      "license": "MIT License"
     },
     "node_modules/xml-name-validator": {
       "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -31,12 +31,14 @@
     "retext-stringify": "^4.0.0",
     "strip-markdown": "^6.0.0",
     "unified": "^11.0.5",
-    "unist-util-visit": "^5.0.0"
+    "unist-util-visit": "^5.0.0",
+    "xml-escape": "^1.1.0"
   },
   "devDependencies": {
     "@astrojs/react": "^5.0.6",
     "@testing-library/react": "^16.3.2",
     "@types/node": "^25.9.1",
+    "@types/xml-escape": "^1.1.3",
     "@types/react": "^19.2.15",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.2.0",

--- a/src/lib/rss.ts
+++ b/src/lib/rss.ts
@@ -1,0 +1,14 @@
+const SITE_URL = 'https://memo.yammer.jp'
+
+const escapeXml = (value: string) => {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&apos;')
+}
+
+const formatRssDate = (value: string) => new Date(value).toUTCString()
+
+export { SITE_URL, escapeXml, formatRssDate }

--- a/src/lib/rss.ts
+++ b/src/lib/rss.ts
@@ -1,14 +1,5 @@
 const SITE_URL = 'https://memo.yammer.jp'
 
-const escapeXml = (value: string) => {
-  return value
-    .replaceAll('&', '&amp;')
-    .replaceAll('<', '&lt;')
-    .replaceAll('>', '&gt;')
-    .replaceAll('"', '&quot;')
-    .replaceAll("'", '&apos;')
-}
-
 const formatRssDate = (value: string) => new Date(value).toUTCString()
 
-export { SITE_URL, escapeXml, formatRssDate }
+export { SITE_URL, formatRssDate }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -14,6 +14,7 @@ const pages = Math.ceil(allPosts.length / postsPerPage)
 
 <Frame titleIsH1={true}>
   <title slot="head">memo.yammer.jp - 常に完成形</title>
+  <link slot="head" rel="alternate" type="application/rss+xml" title="RSS2.0" href="/posts/index.xml" />
   <Ogp
     slot="head"
     title='memo.yammer.jp'

--- a/src/pages/posts/index.astro
+++ b/src/pages/posts/index.astro
@@ -14,6 +14,7 @@ const pages = Math.ceil(allPosts.length / postsPerPage)
 
 <Frame titleIsH1={true}>
   <title slot="head">memo.yammer.jp - 常に完成形</title>
+  <link slot="head" rel="alternate" type="application/rss+xml" title="RSS2.0" href="/posts/index.xml" />
   <Ogp
     slot="head"
     title='memo.yammer.jp'

--- a/src/pages/posts/index.xml.ts
+++ b/src/pages/posts/index.xml.ts
@@ -1,0 +1,48 @@
+import { getAllPosts } from '../../lib/astroApi'
+import { SITE_URL, escapeXml, formatRssDate } from '../../lib/rss'
+
+const buildRss = async () => {
+  const allPosts = await getAllPosts(['title', 'date', 'slug', 'html'])
+  const latestBuildDate = new Date().toUTCString()
+  const copyright = `©${new Date().getFullYear()} Keisuke Nakayama`
+
+  const items = allPosts
+    .map(
+      (post) => `    <item>
+      <title>${escapeXml(post.title)}</title>
+      <link>${escapeXml(`${SITE_URL}/posts/${post.slug}`)}</link>
+      <pubDate>${escapeXml(formatRssDate(post.date))}</pubDate>
+      <guid>${escapeXml(`${SITE_URL}/posts/${post.slug}`)}</guid>
+      <description>${escapeXml(post.html ?? '')}</description>
+    </item>`,
+    )
+    .join('\n')
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<rss xmlns:atom="http://www.w3.org/2005/Atom" version="2.0">
+  <channel>
+    <title>memo.yammer.jp</title>
+    <link>${escapeXml(`${SITE_URL}/posts/`)}</link>
+    <description>Recent content in Posts on memo.yammer.jp</description>
+    <generator>memo.yammer.jp with Astro (https://github.com/yammerjp/memo.yammer.jp)</generator>
+    <language>ja</language>
+    <copyright>${escapeXml(copyright)}</copyright>
+    <lastBuildDate>${escapeXml(latestBuildDate)}</lastBuildDate>
+    <atom:link href="${SITE_URL}/posts/index.xml" rel="self" type="application/rss+xml" />
+${items}
+  </channel>
+</rss>
+`
+}
+
+export const prerender = true
+
+export async function GET() {
+  const body = await buildRss()
+
+  return new Response(body, {
+    headers: {
+      'Content-Type': 'application/rss+xml; charset=utf-8',
+    },
+  })
+}

--- a/src/pages/posts/index.xml.ts
+++ b/src/pages/posts/index.xml.ts
@@ -1,5 +1,7 @@
 import { getAllPosts } from '../../lib/astroApi'
-import { SITE_URL, escapeXml, formatRssDate } from '../../lib/rss'
+import xmlEscape from 'xml-escape'
+
+import { SITE_URL, formatRssDate } from '../../lib/rss'
 
 const buildRss = async () => {
   const allPosts = await getAllPosts(['title', 'date', 'slug', 'html'])
@@ -9,11 +11,11 @@ const buildRss = async () => {
   const items = allPosts
     .map(
       (post) => `    <item>
-      <title>${escapeXml(post.title)}</title>
-      <link>${escapeXml(`${SITE_URL}/posts/${post.slug}`)}</link>
-      <pubDate>${escapeXml(formatRssDate(post.date))}</pubDate>
-      <guid>${escapeXml(`${SITE_URL}/posts/${post.slug}`)}</guid>
-      <description>${escapeXml(post.html ?? '')}</description>
+      <title>${xmlEscape(post.title)}</title>
+      <link>${xmlEscape(`${SITE_URL}/posts/${post.slug}`)}</link>
+      <pubDate>${xmlEscape(formatRssDate(post.date))}</pubDate>
+      <guid>${xmlEscape(`${SITE_URL}/posts/${post.slug}`)}</guid>
+      <description>${xmlEscape(post.html ?? '')}</description>
     </item>`,
     )
     .join('\n')
@@ -22,12 +24,12 @@ const buildRss = async () => {
 <rss xmlns:atom="http://www.w3.org/2005/Atom" version="2.0">
   <channel>
     <title>memo.yammer.jp</title>
-    <link>${escapeXml(`${SITE_URL}/posts/`)}</link>
+    <link>${xmlEscape(`${SITE_URL}/posts/`)}</link>
     <description>Recent content in Posts on memo.yammer.jp</description>
     <generator>memo.yammer.jp with Astro (https://github.com/yammerjp/memo.yammer.jp)</generator>
     <language>ja</language>
-    <copyright>${escapeXml(copyright)}</copyright>
-    <lastBuildDate>${escapeXml(latestBuildDate)}</lastBuildDate>
+    <copyright>${xmlEscape(copyright)}</copyright>
+    <lastBuildDate>${xmlEscape(latestBuildDate)}</lastBuildDate>
     <atom:link href="${SITE_URL}/posts/index.xml" rel="self" type="application/rss+xml" />
 ${items}
   </channel>

--- a/test/integration/astroPages.test.ts
+++ b/test/integration/astroPages.test.ts
@@ -33,4 +33,15 @@ describe('Astro pages integration', () => {
     expect(html).toContain('role="button"')
     expect(html).not.toContain('href="/search"')
   })
+
+  it('serves the RSS feed at /posts/index.xml', async () => {
+    const xml = await readDistHtml('posts/index.xml')
+
+    expect(xml).toContain('<?xml version="1.0" encoding="UTF-8"?>')
+    expect(xml).toContain('<rss xmlns:atom="http://www.w3.org/2005/Atom" version="2.0">')
+    expect(xml).toContain('<link>https://memo.yammer.jp/posts/</link>')
+    expect(xml).toContain('<atom:link href="https://memo.yammer.jp/posts/index.xml" rel="self" type="application/rss+xml" />')
+    expect(xml).toContain('<item>')
+    expect(xml).toContain('/posts/20251215')
+  })
 })


### PR DESCRIPTION
## Summary
- Restore the RSS feed at `/posts/index.xml` as a static Astro endpoint
- Add RSS alternate links on the home page and posts index
- Add an integration test to verify the generated feed

## Verification
- `npm run build:astro`
- `npx vitest --config vitest.integration.config.ts run`
