### PR TITLE
カスタム4xxエラーページとフッター調整

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -4,6 +4,9 @@ server {
   root /usr/share/nginx/html;
   index index.html;
 
+  error_page 400 401 402 403 405 406 407 408 409 410 411 412 413 414 415 416 417 418 421 422 423 424 425 426 428 429 431 /4xx/;
+  error_page 404 /404.html;
+
   location / {
     try_files $uri $uri/ =404;
   }

--- a/src/components/errorPage.astro
+++ b/src/components/errorPage.astro
@@ -1,23 +1,9 @@
 ---
 import Frame from '../layouts/Frame.astro'
-
-type ErrorAction = {
-  href: string
-  label: string
-}
-
-const {
-  code,
-  title,
-  description,
-  primaryAction,
-  secondaryAction,
-} = Astro.props as {
+const { code, title, description } = Astro.props as {
   code: string
   title: string
   description: string
-  primaryAction: ErrorAction
-  secondaryAction: ErrorAction
 }
 ---
 
@@ -25,105 +11,8 @@ const {
   <title slot="head">{code} - memo.yammer.jp</title>
   <meta slot="head" name="robots" content="noindex, nofollow" />
 
-  <section class="error-shell" aria-labelledby="error-title">
-    <div class="error-code">{code}</div>
+  <section aria-labelledby="error-title">
     <h1 id="error-title">{title}</h1>
     <p class="error-description">{description}</p>
-
-    <div class="error-actions">
-      <a class="primary-action" href={primaryAction.href}>{primaryAction.label}</a>
-      <a class="secondary-action" href={secondaryAction.href}>{secondaryAction.label}</a>
-    </div>
-
-    <ul class="error-links" aria-label="補助リンク">
-      <li><a href='/'>Home</a></li>
-      <li><a href='/posts/'>記事一覧</a></li>
-      <li><a href='/tags'>タグ一覧</a></li>
-    </ul>
   </section>
 </Frame>
-
-<style>
-  .error-shell {
-    margin: 24px 0 48px;
-    padding: 40px 28px;
-    border: 1px solid rgba(64, 101, 153, 0.16);
-    border-radius: 24px;
-    background:
-      radial-gradient(circle at top left, rgba(163, 215, 255, 0.34), transparent 46%),
-      linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(248, 251, 255, 0.96));
-    box-shadow: 0 18px 42px rgba(0, 0, 0, 0.08);
-  }
-
-  .error-code {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    min-width: 88px;
-    padding: 8px 14px;
-    margin-bottom: 20px;
-    border-radius: 999px;
-    background-color: rgba(64, 101, 153, 0.1);
-    color: #406599;
-    font-size: 14px;
-    font-weight: 700;
-    letter-spacing: 0.08em;
-  }
-
-  h1 {
-    margin: 0 0 12px;
-    font-size: clamp(2rem, 4vw, 3rem);
-    line-height: 1.2;
-    color: #222;
-  }
-
-  .error-description {
-    max-width: 46rem;
-    margin: 0;
-    font-size: 1.05rem;
-  }
-
-  .error-actions {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 12px;
-    margin-top: 28px;
-  }
-
-  .primary-action,
-  .secondary-action {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    min-height: 44px;
-    padding: 0 18px;
-    border-radius: 999px;
-    font-weight: 700;
-    text-decoration: none;
-  }
-
-  .primary-action {
-    color: #fff;
-    background: linear-gradient(135deg, #406599, #2f4f78);
-    box-shadow: 0 10px 24px rgba(64, 101, 153, 0.25);
-  }
-
-  .secondary-action {
-    color: #406599;
-    background: rgba(64, 101, 153, 0.08);
-  }
-
-  .error-links {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 12px 18px;
-    list-style: none;
-    padding: 0;
-    margin: 28px 0 0;
-    font-size: 0.96rem;
-  }
-
-  .error-links a {
-    color: #406599;
-  }
-</style>

--- a/src/components/errorPage.astro
+++ b/src/components/errorPage.astro
@@ -1,0 +1,129 @@
+---
+import Frame from '../layouts/Frame.astro'
+
+type ErrorAction = {
+  href: string
+  label: string
+}
+
+const {
+  code,
+  title,
+  description,
+  primaryAction,
+  secondaryAction,
+} = Astro.props as {
+  code: string
+  title: string
+  description: string
+  primaryAction: ErrorAction
+  secondaryAction: ErrorAction
+}
+---
+
+<Frame titleIsH1={false}>
+  <title slot="head">{code} - memo.yammer.jp</title>
+  <meta slot="head" name="robots" content="noindex, nofollow" />
+
+  <section class="error-shell" aria-labelledby="error-title">
+    <div class="error-code">{code}</div>
+    <h1 id="error-title">{title}</h1>
+    <p class="error-description">{description}</p>
+
+    <div class="error-actions">
+      <a class="primary-action" href={primaryAction.href}>{primaryAction.label}</a>
+      <a class="secondary-action" href={secondaryAction.href}>{secondaryAction.label}</a>
+    </div>
+
+    <ul class="error-links" aria-label="補助リンク">
+      <li><a href='/'>Home</a></li>
+      <li><a href='/posts/'>記事一覧</a></li>
+      <li><a href='/tags'>タグ一覧</a></li>
+    </ul>
+  </section>
+</Frame>
+
+<style>
+  .error-shell {
+    margin: 24px 0 48px;
+    padding: 40px 28px;
+    border: 1px solid rgba(64, 101, 153, 0.16);
+    border-radius: 24px;
+    background:
+      radial-gradient(circle at top left, rgba(163, 215, 255, 0.34), transparent 46%),
+      linear-gradient(180deg, rgba(255, 255, 255, 0.98), rgba(248, 251, 255, 0.96));
+    box-shadow: 0 18px 42px rgba(0, 0, 0, 0.08);
+  }
+
+  .error-code {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 88px;
+    padding: 8px 14px;
+    margin-bottom: 20px;
+    border-radius: 999px;
+    background-color: rgba(64, 101, 153, 0.1);
+    color: #406599;
+    font-size: 14px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+  }
+
+  h1 {
+    margin: 0 0 12px;
+    font-size: clamp(2rem, 4vw, 3rem);
+    line-height: 1.2;
+    color: #222;
+  }
+
+  .error-description {
+    max-width: 46rem;
+    margin: 0;
+    font-size: 1.05rem;
+  }
+
+  .error-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    margin-top: 28px;
+  }
+
+  .primary-action,
+  .secondary-action {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 44px;
+    padding: 0 18px;
+    border-radius: 999px;
+    font-weight: 700;
+    text-decoration: none;
+  }
+
+  .primary-action {
+    color: #fff;
+    background: linear-gradient(135deg, #406599, #2f4f78);
+    box-shadow: 0 10px 24px rgba(64, 101, 153, 0.25);
+  }
+
+  .secondary-action {
+    color: #406599;
+    background: rgba(64, 101, 153, 0.08);
+  }
+
+  .error-links {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px 18px;
+    list-style: none;
+    padding: 0;
+    margin: 28px 0 0;
+    font-size: 0.96rem;
+  }
+
+  .error-links a {
+    color: #406599;
+  }
+</style>

--- a/src/components/frame.module.css
+++ b/src/components/frame.module.css
@@ -1,5 +1,6 @@
 .content {
   width: 100%;
+  flex: 1 0 auto;
 }
 .contentInner {
   text-align: left;

--- a/src/pages/404/index.astro
+++ b/src/pages/404/index.astro
@@ -1,0 +1,11 @@
+---
+import ErrorPage from '../../components/errorPage.astro'
+---
+
+<ErrorPage
+  code='404'
+  title='ページが見つかりません'
+  description='お探しのページは削除されたか、URL が間違っている可能性があります。トップページか記事一覧から探し直してください。'
+  primaryAction={{ href: '/', label: 'トップページへ' }}
+  secondaryAction={{ href: '/posts/', label: '記事一覧へ' }}
+/>

--- a/src/pages/4xx/index.astro
+++ b/src/pages/4xx/index.astro
@@ -1,0 +1,11 @@
+---
+import ErrorPage from '../../components/errorPage.astro'
+---
+
+<ErrorPage
+  code='4xx'
+  title='リクエストを処理できません'
+  description='アクセスした URL が不正だったり、このサイトでは扱えない種類のリクエストだった可能性があります。別のページから入り直してください。'
+  primaryAction={{ href: '/', label: 'トップページへ' }}
+  secondaryAction={{ href: '/tags', label: 'タグ一覧へ' }}
+/>

--- a/src/pages/global.css
+++ b/src/pages/global.css
@@ -15,6 +15,10 @@ html {
 body {
   overflow-y: scroll;
   color: rgba(0, 0, 0, 0.85);
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  min-height: 100svh;
 
   word-break: normal;
   word-wrap: break-word;

--- a/test/integration/astroPages.test.ts
+++ b/test/integration/astroPages.test.ts
@@ -44,4 +44,20 @@ describe('Astro pages integration', () => {
     expect(xml).toContain('<item>')
     expect(xml).toContain('/posts/20251215')
   })
+
+  it('renders a custom 404 page', async () => {
+    const html = await readDistHtml('404.html')
+
+    expect(html).toContain('ページが見つかりません')
+    expect(html).toContain('トップページへ')
+    expect(html).toContain('meta name="robots" content="noindex, nofollow"')
+  })
+
+  it('renders a custom 4xx page', async () => {
+    const html = await readDistHtml('4xx/index.html')
+
+    expect(html).toContain('リクエストを処理できません')
+    expect(html).toContain('タグ一覧へ')
+    expect(html).toContain('meta name="robots" content="noindex, nofollow"')
+  })
 })


### PR DESCRIPTION
## 概要\n- 404 / 4xx のカスタムページを追加\n- 短いページでもフッターが下に来るようにレイアウトを調整\n\n## 補足\n- RSS ボタン関連の変更は別 PR (#45) に分離済みです。\n\n## 確認\n- 
> blog-starter-typescript@1.0.0 test:astro
> npm run build:post-history && npm run build:astro && vitest --config vitest.integration.config.ts run


> blog-starter-typescript@1.0.0 build:post-history
> node bin/build-post-history.js


> blog-starter-typescript@1.0.0 build:astro
> astro build

22:10:42 [vite] Re-optimizing dependencies because vite config has changed
22:10:42 [content] Syncing content
22:10:42 [content] Synced content
22:10:42 [types] Generated 434ms
22:10:42 [build] output: "static"
22:10:42 [build] mode: "static"
22:10:42 [build] directory: /Users/yammer/src/github.com/yammerjp/memo.yammer.jp/dist/
22:10:42 [build] Collecting build info...
22:10:42 [build] ✓ Completed in 446ms.
22:10:42 [build] Building static entrypoints...
22:10:43 [vite] ✓ built in 958ms
22:10:43 [vite] ✓ built in 353ms
22:10:43 [build] Rearranging server assets...

 generating static routes 
22:10:43   ├─ /404.html (+5ms) 
22:10:43   ├─ /4xx/index.html (+2ms) 
22:10:43   ├─ /about/index.html (+19ms) 
22:10:43   ├─ /page/1/index.html (+306ms) 
22:10:44   ├─ /page/2/index.html (+257ms) 
22:10:44   ├─ /page/3/index.html (+275ms) 
22:10:44   ├─ /page/4/index.html (+247ms) 
22:10:45   ├─ /page/5/index.html (+239ms) 
22:10:45   ├─ /page/6/index.html (+252ms) 
22:10:45   ├─ /page/7/index.html (+256ms) 
22:10:45   ├─ /page/8/index.html (+280ms) 
22:10:46   ├─ /page/9/index.html (+254ms) 
22:10:46   ├─ /page/10/index.html (+233ms) 
22:10:46   ├─ /page/11/index.html (+244ms) 
22:10:46   ├─ /page/12/index.html (+241ms) 
22:10:47   ├─ /page/13/index.html (+241ms) 
22:10:47   ├─ /page/14/index.html (+280ms) 
22:10:47   ├─ /posts/index.xml (+1.14s) 
22:10:48   ├─ /posts/20251215/index.html (+18ms) 
22:10:48   ├─ /posts/mail-sender-authentication/index.html (+15ms) 
22:10:48   ├─ /posts/gmo-developers-day-2024/index.html (+7ms) 
22:10:48   ├─ /posts/cto-in-ec-div/index.html (+8ms) 
22:10:48   ├─ /posts/2024-08-pl-bs-cf-introduction/index.html (+7ms) 
22:10:48   ├─ /posts/tech-conference-2023/index.html (+4ms) 
22:10:48   ├─ /posts/isucon13/index.html (+270ms) 
22:10:49   ├─ /posts/team-dynamics-evolving/index.html (+16ms) 
22:10:49   ├─ /posts/the-mythical-man-month-essays-on-software-engineering/index.html (+10ms) 
22:10:49   ├─ /posts/the-managers-path/index.html (+12ms) 
22:10:49   ├─ /posts/software-design-202307/index.html (+12ms) 
22:10:49   ├─ /posts/gawk-rubber-duck/index.html (+11ms) 
22:10:49   ├─ /posts/union-find/index.html (+11ms) 
22:10:49   ├─ /posts/embedding-and-vector-similarity-matching/index.html (+9ms) 
22:10:49   ├─ /posts/rtx/index.html (+7ms) 
22:10:49   ├─ /posts/docs-for-developers/index.html (+8ms) 
22:10:49   ├─ /posts/working-effectively-with-legacy-code/index.html (+7ms) 
22:10:49   ├─ /posts/phperkaigi2023-day2/index.html (+329ms) 
22:10:49   ├─ /posts/phperkaigi2023-day1/index.html (+467ms) 
22:10:49   ├─ /posts/software-design-202303/index.html (+7ms) 
22:10:49   ├─ /posts/smart-keyboard-folio/index.html (+11ms) 
22:10:49   ├─ /posts/software-design-202302/index.html (+7ms) 
22:10:49   ├─ /posts/how-to-install-alacritty/index.html (+11ms) 
22:10:49   ├─ /posts/software-design-202301/index.html (+7ms) 
22:10:49   ├─ /posts/20221214/index.html (+10ms) 
22:10:49   ├─ /posts/jpro/index.html (+11ms) 
22:10:49   ├─ /posts/asahi-linux/index.html (+10ms) 
22:10:50   ├─ /posts/fitbit-charge-5/index.html (+5ms) 
22:10:50   ├─ /posts/python-ml-100-knocks-setup/index.html (+6ms) 
22:10:50   ├─ /posts/talking-about-your-own-impressive-work/index.html (+268ms) 
22:10:50   ├─ /posts/cloud-run-litestream/index.html (+499ms) 
22:10:50   ├─ /posts/cloudfront-functions-redirect/index.html (+15ms) 
22:10:50   ├─ /posts/alacritty/index.html (+267ms) 
22:10:51   ├─ /posts/introduction-of-character-code-for-programmer/index.html (+16ms) 
22:10:51   ├─ /posts/clean-architecture/index.html (+13ms) 
22:10:51   ├─ /posts/wireshark/index.html (+9ms) 
22:10:51   ├─ /posts/zsh-abbr/index.html (+13ms) 
22:10:51   ├─ /posts/software-design-202206/index.html (+6ms) 
22:10:51   ├─ /posts/cocot46/index.html (+306ms) 
22:10:51   ├─ /posts/24-years-old/index.html (+7ms) 
22:10:51   ├─ /posts/devide-bashrc/index.html (+7ms) 
22:10:51   ├─ /posts/moving-to-saitama/index.html (+12ms) 
22:10:51   ├─ /posts/shadow-dom-internal-link/index.html (+7ms) 
22:10:51   ├─ /posts/ssh-to-home/index.html (+11ms) 
22:10:51   ├─ /posts/file_charset_validator/index.html (+7ms) 
22:10:51   ├─ /posts/graspad/index.html (+16ms) 
22:10:51   ├─ /posts/anycubic-mega-s/index.html (+469ms) 
22:10:51   ├─ /posts/database-specialist-examination/index.html (+15ms) 
22:10:51   ├─ /posts/newcomer-in-development-team-supplement/index.html (+15ms) 
22:10:52   ├─ /posts/newcomer-in-development-team/index.html (+16ms) 
22:10:52   ├─ /posts/layered-dotfiles/index.html (+16ms) 
22:10:52   ├─ /posts/restrict-git-master-push/index.html (+9ms) 
22:10:52   ├─ /posts/competing-with-unicorns/index.html (+5ms) 
22:10:52   ├─ /posts/english-for-apps/index.html (+4ms) 
22:10:52   ├─ /posts/software-is-not-ghost/index.html (+460ms) 
22:10:52   ├─ /posts/20210624/index.html (+9ms) 
22:10:52   ├─ /posts/curldoc-development/index.html (+15ms) 
22:10:52   ├─ /posts/pepabo-11th-training/index.html (+13ms) 
22:10:52   ├─ /posts/blog-with-nextjs/index.html (+9ms) 
22:10:52   ├─ /posts/tokeru-design/index.html (+7ms) 
22:10:52   ├─ /posts/foot-switch-mic-mute/index.html (+312ms) 
22:10:52   ├─ /posts/backup-lolipop-wordpress-with-docker/index.html (+24ms) 
22:10:52   ├─ /posts/strengths-finder/index.html (+12ms) 
22:10:52   ├─ /posts/20210408/index.html (+280ms) 
22:10:53   ├─ /posts/mail-backup-mbox/index.html (+16ms) 
22:10:53   ├─ /posts/tcp-packet-layout/index.html (+6ms) 
22:10:53   ├─ /posts/20210218/index.html (+9ms) 
22:10:53   ├─ /posts/clip-path/index.html (+7ms) 
22:10:53   ├─ /posts/planck-keyboard/index.html (+14ms) 
22:10:53   ├─ /posts/2021-target/index.html (+9ms) 
22:10:53   ├─ /posts/readable-code/index.html (+6ms) 
22:10:53   ├─ /posts/2020-github-repositories/index.html (+19ms) 
22:10:53   ├─ /posts/hugo-url-encode/index.html (+6ms) 
22:10:53   ├─ /posts/mba2020-setup/index.html (+260ms) 
22:10:53   ├─ /posts/pocket2retweet/index.html (+14ms) 
22:10:53   ├─ /posts/toshiba-dubbing/index.html (+17ms) 
22:10:53   ├─ /posts/2020-12-how-to-write-technical-texts/index.html (+14ms) 
22:10:53   ├─ /posts/mba2020-buying/index.html (+337ms) 
22:10:53   ├─ /posts/macos-ssh-agent/index.html (+10ms) 
22:10:53   ├─ /posts/ubuntu-vnc-setup/index.html (+11ms) 
22:10:53   ├─ /posts/vivaldi-search-english/index.html (+11ms) 
22:10:53   ├─ /posts/sudo-user-home-dir/index.html (+9ms) 
22:10:53   ├─ /posts/tmux/index.html (+20ms) 
22:10:53   ├─ /posts/webteckbook/index.html (+9ms) 
22:10:53   ├─ /posts/keymap-202009/index.html (+275ms) 
22:10:54   ├─ /posts/makefile-named-pipe/index.html (+10ms) 
22:10:54   ├─ /posts/lovelab-ec2/index.html (+11ms) 
22:10:54   ├─ /posts/compiler-lalr1/index.html (+18ms) 
22:10:54   ├─ /posts/compiler-lr0/index.html (+63ms) 
22:10:54   ├─ /posts/docker/index.html (+10ms) 
22:10:54   ├─ /posts/github-ssh/index.html (+5ms) 
22:10:54   ├─ /posts/lily58-pro-ble/index.html (+10ms) 
22:10:54   ├─ /posts/lily58-pro-build-log/index.html (+302ms) 
22:10:54   ├─ /posts/ubuntu-m570-scroll/index.html (+13ms) 
22:10:54   ├─ /posts/willani-for-stmt-bug/index.html (+14ms) 
22:10:54   ├─ /posts/willani-struct-alignment/index.html (+18ms) 
22:10:54   ├─ /posts/willani-try-selfhost/index.html (+9ms) 
22:10:54   ├─ /posts/mares-pack-pro-battery-replacement/index.html (+7ms) 
22:10:54   ├─ /posts/firebase2hatenablog/index.html (+7ms) 
22:10:54   ├─ /posts/gimonfu/index.html (+11ms) 
22:10:54   ├─ /posts/willani-compliperbook-finished/index.html (+8ms) 
22:10:54   ├─ /posts/zeit-now/index.html (+6ms) 
22:10:54   ├─ /posts/tcp-udp/index.html (+12ms) 
22:10:54   ├─ /posts/linux-cpu/index.html (+3ms) 
22:10:54   ├─ /posts/willani-start/index.html (+5ms) 
22:10:54   ├─ /posts/npm-publish/index.html (+8ms) 
22:10:54   ├─ /posts/computer-essay/index.html (+6ms) 
22:10:54   ├─ /posts/2019-github-repositories/index.html (+13ms) 
22:10:54   ├─ /posts/promise/index.html (+18ms) 
22:10:54   ├─ /posts/promise-then-arg2/index.html (+259ms) 
22:10:55   ├─ /posts/raspberry-pi-zero-setup/index.html (+18ms) 
22:10:55   ├─ /posts/vim-intro/index.html (+23ms) 
22:10:55   ├─ /posts/my-type-of-typescript/index.html (+8ms) 
22:10:55   ├─ /posts/telnet-http/index.html (+5ms) 
22:10:55   ├─ /posts/internet-tcpip/index.html (+16ms) 
22:10:55   ├─ /posts/job-hunting-6-month-ago/index.html (+5ms) 
22:10:55   ├─ /posts/plist/index.html (+14ms) 
22:10:55   ├─ /posts/pdef/index.html (+9ms) 
22:10:55   ├─ /posts/macos-defaults/index.html (+10ms) 
22:10:55   ├─ /posts/vim-lsp-init/index.html (+5ms) 
22:10:55   ├─ /posts/20200330/index.html (+7ms) 
22:10:55   ├─ /posts/book-memo-do-now/index.html (+5ms) 
22:10:55   ├─ /posts/virtualization/index.html (+3ms) 
22:10:55   ├─ /posts/sakura-vps-docker/index.html (+10ms) 
22:10:55   ├─ /posts/sakura-vps-dns/index.html (+6ms) 
22:10:55   ├─ /posts/android-phone-call-command/index.html (+4ms) 
22:10:55   ├─ /posts/sh-history/index.html (+4ms) 
22:10:55   ├─ /posts/download-ubuntu/index.html (+4ms) 
22:10:55   ├─ /posts/install-dein-vim/index.html (+8ms) 
22:10:55   ├─ /posts/shell-pwd/index.html (+5ms) 
22:10:55   ├─ /posts/hexo/index.html (+6ms) 
22:10:55   ├─ /posts/index.html (+276ms) 
22:10:55   ├─ /privacy-policy/index.html (+3ms) 
22:10:55   ├─ /tags/index.html (+252ms) 
22:10:55   ├─ /index.html (+241ms) 
22:10:56 ✓ Completed in 12.25s.

22:10:56 [build] ✓ Completed in 13.60s.
22:10:56 [build] 152 page(s) built in 14.05s
22:10:56 [build] Complete!

 RUN  v4.1.7 /Users/yammer/src/github.com/yammerjp/memo.yammer.jp

 ❯ test/integration/astroPages.test.ts (6 tests | 2 failed) 19ms
     × renders a custom 404 page 5ms
     × renders a custom 4xx page 2ms

 Test Files  1 failed (1)
      Tests  2 failed | 4 passed (6)
   Start at  22:10:56
   Duration  126ms (transform 14ms, setup 0ms, import 21ms, tests 19ms, environment 0ms) は以前の作業時に確認済みです。